### PR TITLE
Add ruff linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,12 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.3
+    hooks:
+      - id: ruff
+        types: [file]
+        types_or: [python, pyi, toml]
   - repo: https://github.com/CoolCat467/badgie
     rev: v0.9.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Python program that implements a simple convolutional neural network (CNN) using
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![code style: black](https://img.shields.io/badge/code_style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 <!-- END BADGIE TIME -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,42 @@ dependencies = [
 "Source" = "https://github.com/thomasthaddeus/NeuralNetworks"
 "Bug Tracker" = "https://github.com/thomasthaddeus/NeuralNetworks/issues"
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 [tool.black]
 line-length = 79
 target-version = ['py311']
+
+[tool.ruff]
+line-length = 79
+fix = true
+
+include = ["*.py", "*.pyi", "**/pyproject.toml"]
+
+[tool.ruff.lint]
+select = [
+    "A",     # flake8-builtins
+    "ASYNC", # flake8-async
+    "E",     # Error
+    "EXE",   # flake8-executable
+    "FA",    # flake8-future-annotations
+    "I",     # isort
+    "PIE",   # flake8-pie
+    "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
+    "RET",   # flake8-return
+    "RUF",   # Ruff-specific rules
+    "S",     # flake8-bandit
+    "SIM",   # flake8-simplify
+    "SLOT",  # flake8-slots
+    "TCH",   # flake8-type-checking
+    "UP",    # pyupgrade
+    "W",     # Warning
+    "YTT",   # flake8-2020
+]
+extend-ignore = [
+    "E501",   # line-too-long
+    "S101",   # use of assert for tests and type narrowing
+    "SIM117", # Use multiple with statements at the same time
+]

--- a/src/pipeline/mnist_keras_model.py
+++ b/src/pipeline/mnist_keras_model.py
@@ -39,9 +39,10 @@ Author:
 """
 
 from typing import Tuple
+
 from keras.datasets import mnist
-from keras.models import Sequential
 from keras.layers import Dense
+from keras.models import Sequential
 from keras.utils import to_categorical
 from numpy.typing import NDArray
 
@@ -86,7 +87,7 @@ class MnistKerasModel:
 
     def load_data(
         self,
-    ) -> Tuple[Tuple[NDArray, NDArray], Tuple[NDArray, NDArray]]:
+    ) -> tuple[tuple[NDArray, NDArray], tuple[NDArray, NDArray]]:
         """
         Load the MNIST dataset.
 

--- a/src/pipeline/mnist_keras_model.py
+++ b/src/pipeline/mnist_keras_model.py
@@ -38,8 +38,6 @@ Author:
     Thaddeus Thomas
 """
 
-from typing import Tuple
-
 from keras.datasets import mnist
 from keras.layers import Dense
 from keras.models import Sequential

--- a/src/pipeline/trainer.py
+++ b/src/pipeline/trainer.py
@@ -24,9 +24,9 @@ train_step(train_x, train_y): Perform a single training step.
 fit(train_x, train_y, epochs): Train the model on the given data for the specified number of epochs.
 """
 
-from keras.optimizers import Adam
-from keras.losses import CategoricalCrossentropy
 import tensorflow as tf
+from keras.losses import CategoricalCrossentropy
+from keras.optimizers import Adam
 
 
 class Trainer:

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -16,12 +16,12 @@ Extended Summary:
 
 # Add the necessary imports
 from data_preparation import DataPreparation
+from models.cnn import CNNModel
+from models.knn import KNNModel
+from models.rnn import RNN
+from sklearn import preprocessing
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
-from sklearn import preprocessing
-from models.knn import KNNModel
-from models.cnn import CNNModel
-from models.rnn import RNN
 from visualization.viz import Visualization
 
 

--- a/src/python/models/cnn.py
+++ b/src/python/models/cnn.py
@@ -85,14 +85,13 @@ class CNNModel:
                 "Please call build_model before training."
             )
 
-        history = self.model.fit(
+        return self.model.fit(
             X_train,
             y_train,
             epochs=epochs,
             batch_size=batch_size,
             validation_data=(X_test, y_test),
         )
-        return history
 
     def evaluate(self, X_test, y_test) -> None:
         """

--- a/src/python/models/cnn.py
+++ b/src/python/models/cnn.py
@@ -11,12 +11,12 @@ Usage:
     cnn.evaluate(x_test, y_test)
 """
 
-import numpy as np
-from keras.models import Sequential
-from keras.layers import Conv2D, MaxPooling2D, Flatten, Dense
-from keras.datasets import mnist
-from keras.utils import to_categorical, plot_model
 import matplotlib.pyplot as plt
+import numpy as np
+from keras.datasets import mnist
+from keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
+from keras.models import Sequential
+from keras.utils import plot_model, to_categorical
 from matplotlib import image
 
 

--- a/src/python/models/knn.py
+++ b/src/python/models/knn.py
@@ -14,11 +14,10 @@ scikit-learn library. The k-NN model can be trained, used for predictions, and
 evaluated using this module.
 """
 
-from sklearn.metrics import accuracy_score, mean_squared_error
-from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
-from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_iris
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import accuracy_score, mean_squared_error
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
 
 class KNNModel:

--- a/src/python/models/knn.py
+++ b/src/python/models/knn.py
@@ -137,9 +137,8 @@ class KNNModel:
         if return_distance:
             distances, _ = self.knn.kneighbors(var_x)
             return distances
-        else:
-            _, indices = self.knn.kneighbors(var_x)
-            return indices
+        _, indices = self.knn.kneighbors(var_x)
+        return indices
 
 
 def knn_main():

--- a/src/python/models/rnn.py
+++ b/src/python/models/rnn.py
@@ -22,10 +22,10 @@ Returns:
 """
 
 import tensorflow as tf
+from keras.layers import LSTM, Conv2D, Dense, Flatten, MaxPooling2D
+from keras.models import Model, Sequential
 from sklearn.feature_selection import SequentialFeatureSelector
 from sklearn.neighbors import KNeighborsClassifier
-from keras.models import Model, Sequential
-from keras.layers import Conv2D, MaxPooling2D, Flatten, LSTM, Dense
 
 
 class RNN:

--- a/src/setup_nn.py
+++ b/src/setup_nn.py
@@ -1,12 +1,11 @@
 import pandas as pd
 import tensorflow
-from sklearn.model_selection import train_test_split
-from sklearn.compose import ColumnTransformer
-from sklearn.preprocessing import StandardScaler
+from keras.layers import Dense, InputLayer
 from keras.models import Sequential
-from keras.layers import InputLayer
-from keras.layers import Dense
 from keras.optimizers import Adam
+from sklearn.compose import ColumnTransformer
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
 
 tensorflow.random.set_seed(35)  # for the reproducibility of results
 

--- a/src/setup_nn.py
+++ b/src/setup_nn.py
@@ -13,9 +13,9 @@ tensorflow.random.set_seed(35)  # for the reproducibility of results
 def design_model(features):
     model = Sequential(name="my_first_model")
     # without hard-coding
-    input = InputLayer(input_shape=(features.shape[1],))
+    input_ = InputLayer(input_shape=(features.shape[1],))
     # add the input layer
-    model.add(input)
+    model.add(input_)
     # add a hidden layer with 64 neurons
     model.add(Dense(128, activation="relu"))
     # add an output layer to our model

--- a/src/tests/test_cnn.py
+++ b/src/tests/test_cnn.py
@@ -4,6 +4,7 @@ This module contains unit tests for the CNNModel class.
 """
 
 import unittest
+
 import numpy as np
 from python.models.cnn import CNNModel
 

--- a/src/tests/test_knn.py
+++ b/src/tests/test_knn.py
@@ -6,9 +6,10 @@ _extended_summary_
 """
 
 import unittest
+
 import numpy as np
-from sklearn.datasets import make_classification
 from python.models.knn import KNNModel
+from sklearn.datasets import make_classification
 
 
 class TestKNearestNeighbors(unittest.TestCase):


### PR DESCRIPTION
This pull request adds the `ruff-pre-commit` hook. [Ruff](https://docs.astral.sh/ruff/) is a super fast linter and formatter with support for quite literally hundreds of supported rules from other linters such as flake8, without being nearly as slow.

I've enabled a few of the most common rules ruff supports initially, but if there are any changes you don't like very much I can find out what rule caused that specific change.

Link to current rules ruff supports: https://docs.astral.sh/ruff/rules/